### PR TITLE
Handle redirect manually

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,6 @@
 {
     "plugins": ["@typescript-eslint"],
     "extends": [
-      "plugin:github/recommended",
       "oclif",
       "oclif-typescript"
     ],
@@ -12,7 +11,10 @@
       "project": "./tsconfig.json"
     },
     "rules": {
+      "comma-dangle": "off",
       "no-console": "off",
+      "no-process-exit": "off",
+      "unicorn/no-process-exit": "off",
       "eslint-comments/no-use": "off",
       "import/no-namespace": "off",
       "no-unused-vars": "off",

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2018 GitHub, Inc. and contributors
+Copyright (c) 2020 Kengo TODA
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package-lock.json
+++ b/package-lock.json
@@ -762,6 +762,12 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
+    "@types/debug": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
+      "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==",
+      "dev": true
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -11,11 +11,13 @@
     "@oclif/command": "^1.8.0",
     "@oclif/config": "^1.17.0",
     "@oclif/plugin-help": "^3.2.1",
+    "debug": "^4.3.1",
     "open": "^7.3.0",
     "tslib": "^2.0.3"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.26.0",
+    "@types/debug": "^4.1.5",
     "@typescript-eslint/parser": "^4.9.1",
     "eslint": "^7.15.0",
     "eslint-config-oclif": "^3.1.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,9 @@ import {hostname} from 'os'
 import open from 'open'
 import {createInterface} from 'readline'
 import {generateKeyPairSync, privateDecrypt, constants} from 'crypto'
+import debug from 'debug'
 
+const print = debug('discourse-api-key-generator')
 const {publicKey, privateKey} = generateKeyPairSync('rsa', {
   modulusLength: 4096,
   publicKeyEncoding: {
@@ -29,7 +31,7 @@ function buildUrl(site: string, applicationName: string): string {
   url.searchParams.append('scopes', 'write')
   url.searchParams.append('public_key', publicKey)
   url.searchParams.append('nonce', '1')
-  console.debug(`redirect URL is ${url.href}`)
+  print(`redirect URL is ${url.href}`)
   return url.href
 }
 
@@ -70,7 +72,7 @@ class DiscourseApiKeyGenerator extends Command {
       'Please input the encoded key displayed in the Discourse:',
       encodedKey => {
         const trim = encodedKey.trim().replace(/\s/g, '')
-        console.debug(`trimmed encoded key is ${trim}`)
+        print(`trimmed encoded key is ${trim}`)
         const decreptedKey = privateDecrypt(
           {
             key: privateKey,
@@ -79,10 +81,10 @@ class DiscourseApiKeyGenerator extends Command {
           Buffer.from(trim, 'base64')
         )
         const json = decreptedKey.toString('ascii')
-        console.debug(`The decoded json is ${json}`)
+        print(`The decoded json is ${json}`)
         readline.close()
 
-        console.info(`Done. The API key is ${JSON.parse(json).key}.`)
+        console.info(`Done. The API key is ${JSON.parse(json).key}`)
         process.exit(0)
       }
     )


### PR DESCRIPTION
According to https://meta.discourse.org/t/can-non-admin-user-issue-their-own-api-key/173226/10 we cannot use redirect to get the decoded token from discourse, so ask user to input it manually.

So now this repo is quite similar to the ruby code described at https://meta.discourse.org/t/generating-user-api-keys-for-testing/145744